### PR TITLE
Add 'download_rpg_data' binary

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -384,6 +384,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,6 +2219,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,6 +3108,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinoff"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20aa2ed67fbb202e7b716ff8bfc6571dd9301617767380197d701c31124e88f6"
+dependencies = [
+ "colored",
+ "once_cell",
+ "paste",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3953,6 +3980,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "spinoff",
  "strum",
  "strum_macros",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,4 +23,6 @@ rusqlite = { version = "0.32.1", features = ["bundled"] }
 git2 = "0.19.0" # Bindings to libgit2 for interoperating with git repositories. This library is both threadsafe and memory safe and allows both reading and writing git repositories. 
 strum = { version = "0.26" }
 strum_macros = { version = "0.26" }
+spinoff = "0.8.0" # an easy to use, robust library for displaying spinners in the terminal
+
 

--- a/src-tauri/src/bin/download_rpg_data.rs
+++ b/src-tauri/src/bin/download_rpg_data.rs
@@ -1,0 +1,6 @@
+use vitruvian_vtt_lib::ingestion::pf2e::Pf2eWorld;
+use vitruvian_vtt_lib::ingestion::RolePlayingGame;
+
+fn main() {
+    Pf2eWorld::install();
+}

--- a/src-tauri/src/ingestion/pf2e/mod.rs
+++ b/src-tauri/src/ingestion/pf2e/mod.rs
@@ -1,7 +1,11 @@
-use std::{env, path::{Path, PathBuf}};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 use classes::Class;
 use git2::Repository;
+use spinoff::{spinners, Color, Spinner};
 
 use super::{Ingest, RolePlayingGame};
 
@@ -32,11 +36,14 @@ impl RolePlayingGame for Pf2eWorld {
             println!("Pf2e repository already installed locally");
         } else {
             println!("Cloning pf2e repository...");
+            println!("(This may take 5-10 minutes)");
+            let mut spinner = Spinner::new(spinners::Dots, "Loading...", Color::Blue);
             let repo_url = "https://github.com/foundryvtt/pf2e.git";
             match Repository::clone(repo_url, Self::path()) {
                 Ok(_) => (),
                 Err(e) => panic!("Failed to clone repository: {}", e),
             }
+            spinner.success("Done!");
         }
     }
 }


### PR DESCRIPTION
Fixes #20 

This can be run with the `cargo run --bin download_rpg_data` command. 

Currently we only have one rpg to pull (Pathfinder Second Edition). We can update this later to optionally pull in RPGs.

note: I added the spinner library because it was fun and looks great when running (see attached video + image) 

[Screencast from 08-27-2024 09:25:33 PM.webm](https://github.com/user-attachments/assets/180eebe7-8690-45fc-9ac0-4fc57be78b83)
![Screenshot from 2024-08-27 21-30-54](https://github.com/user-attachments/assets/413f43ca-e3b2-47a6-9600-4fb4865addcd)
