### PR TITLE
Change visibility of internal Pf2e ingestion modules

### DIFF
--- a/src-tauri/src/ingestion/pf2e/mod.rs
+++ b/src-tauri/src/ingestion/pf2e/mod.rs
@@ -9,8 +9,8 @@ use spinoff::{spinners, Color, Spinner};
 
 use super::{Ingest, RolePlayingGame};
 
-pub mod classes;
-pub mod core;
+mod classes;
+mod core;
 
 /// The P2FE world of data.
 ///


### PR DESCRIPTION
Small change to reduce unwanted access of internal ingestion modules. 

Auto merging in cause super tiny and on my mind.